### PR TITLE
Fix: login error handing & features enabled by default

### DIFF
--- a/web/utils/handlers.py
+++ b/web/utils/handlers.py
@@ -3,7 +3,7 @@
 import logging as log
 import math
 from datetime import datetime
-from typing import List
+from typing import List, Tuple
 
 import streamlit as st
 from docq import config, domain, run_queries
@@ -160,7 +160,7 @@ def handle_archive_space(id_: int):
     mspaces.archive_space(id_)
 
 
-def _prepare_space_data_source(prefix: str) -> (str, dict):
+def _prepare_space_data_source(prefix: str) -> Tuple[str, dict]:
     ds_type = st.session_state[f"{prefix}ds_type"]
     ds_config_keys = list_space_data_source_choices()[ds_type]
     ds_configs = {key.key: st.session_state[f"{prefix}ds_config_{key.key}"] for key in ds_config_keys}

--- a/web/utils/layout.py
+++ b/web/utils/layout.py
@@ -119,7 +119,8 @@ def auth_required(show_login_form: bool = True, requiring_admin: bool = False, s
 
 def feature_enabled(feature: FeatureKey) -> bool:
     feats = get_enabled_features()
-    if not feats or feature.value not in feats:
+    # Note that we are checking `feats` first and then using `not in` here because we want to allow the features to be enabled by default.
+    if feats and feature.value not in feats:
         st.error("This feature is not enabled.")
         st.info("Please contact your administrator to enable this feature.")
         st.stop()


### PR DESCRIPTION
## Description

Two issues:

- Invalid username/password renders an ugly Python error message, which should be better handled with user-friendly message
- Features such as "Ask Shared Documents" etc. are disabled by default because of lack of system settings when the system is first booted

As fixes, now we have a) better login error message and b) features enabled by default until being explicitly disabled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor and code improvement (non-breaking change which improves code quality and/or performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Tests
- [ ] Other chores such as maintenance

## How Has This Been Tested?

Manually tested for now.

**Test Configuration**:

Please describe the test setup. List them below as bullet points.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] The commit message follows the convention of this project