### PR TITLE
Fix/empty Space indexes crashes shared chat

### DIFF
--- a/source/docq/support/llm.py
+++ b/source/docq/support/llm.py
@@ -1,7 +1,6 @@
 """Functions for utilising LLMs."""
 
 import logging as log
-import traceback
 
 from langchain.chat_models import ChatOpenAI
 from langchain.schema import BaseMessage
@@ -20,12 +19,10 @@ from llama_index.node_parser import SimpleNodeParser
 from llama_index.node_parser.extractors import (
     KeywordExtractor,
     MetadataExtractor,
-    # MetadataFeatureExtractor,
     QuestionsAnsweredExtractor,
     SummaryExtractor,
     TitleExtractor,
 )
-from llama_index.response.schema import RESPONSE_TYPE
 
 from ..config import EXPERIMENTS
 from ..domain import SpaceKey
@@ -152,7 +149,7 @@ def run_ask(input_: str, history: str, space: SpaceKey = None, spaces: list[Spac
                     indices.append(index_)
                     summaries.append(summary_.response)
                 else:
-                    log.warning("The summary generated for Space '%s' was empty so skipping the frin Graph index.", s_)
+                    log.warning("The summary generated for Space '%s' was empty so skipping from the Graph index.", s_)
                     continue
             except Exception as e:
                 log.warning(
@@ -160,7 +157,6 @@ def run_ask(input_: str, history: str, space: SpaceKey = None, spaces: list[Spac
                     s_,
                     e,
                 )
-                log.error(traceback.format_exc())
                 continue
 
         log.debug("number summaries: %s", len(summaries))
@@ -176,7 +172,6 @@ def run_ask(input_: str, history: str, space: SpaceKey = None, spaces: list[Spac
                 "Failed to create ComposableGraph. Maybe there was an issue with one of the Space indexes. Error message: %s",
                 e,
             )
-            log.error(traceback.format_exc())
     else:
         # No additional spaces i.e. likely to be against a user's documents in their personal space.
         if space is None:

--- a/source/docq/support/llm.py
+++ b/source/docq/support/llm.py
@@ -104,7 +104,7 @@ def _get_node_parser() -> SimpleNodeParser:
 
     node_parser = (
         SimpleNodeParser.from_defaults(  # SimpleNodeParser is the default when calling ServiceContext.from_defaults()
-            metadata_extractor=metadata_extractor,  # adds extracted metatdata as extra_info
+            metadata_extractor=metadata_extractor,  # adds extracted metadata as extra_info
         )
     )
 


### PR DESCRIPTION
## Description

We should also handle this on the indexing side better but that's for a separate PR.

#70

If there's no reponse generated from an LLM, like a code crash, now the default response returned is set to `_default_response()` which is "I don't know"

Catches exceptions when loading an index and skips including that index in the query. 

Catches empty summary generation over an index and skips the index from the query.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor and code improvement (non-breaking change which improves code quality and/or performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Tests
- [ ] Other chores such as maintenance

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration by modifying the list below.

- [ ] Test A
- [ ] Test B
- [ ] Test C

**Test Configuration**:

Please describe the test setup. List them below as bullet points.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] The commit message follows the convention of this project