### PR TITLE
fix: getting a selected assistant from across global and org scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docq"
-version = "0.9.1"
+version = "0.9.3"
 description = "Docq.AI - private and secure ChatGPT alternative that unlocks knowledge from your confidential documents."
 authors = ["Docq.AI Team <support@docqai.com>"]
 maintainers = ["Docq.AI Team <support@docqai.com>"]

--- a/source/docq/manage_assistants.py
+++ b/source/docq/manage_assistants.py
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS assistants (
 )
 """
 
-ASSISTANT = tuple[int, str, str, bool, str, str, str, datetime, datetime]
+ASSISTANT = tuple[int, str, str, bool, str, str, str, datetime, datetime, str]
 
 
 def _init(org_id: Optional[int] = None) -> None:
@@ -164,10 +164,10 @@ def get_personas_fixed(assistant_type: Optional[AssistantType] = None) -> dict[s
     return result
 
 
-def get_assistant_or_default(assistant_id: Optional[int] = None, org_id: Optional[int] = None) -> Assistant:
+def get_assistant_or_default(assistant_scoped_id: Optional[int] = None, org_id: Optional[int] = None) -> Assistant:
     """Get the persona."""
-    if assistant_id:
-        assistant_data = get_assistant(assistant_id=assistant_id, org_id=org_id)
+    if assistant_scoped_id:
+        assistant_data = get_assistant(assistant_scoped_id=assistant_scoped_id, org_id=org_id)
         return Assistant(
             key=str(assistant_data[0]),
             name=assistant_data[1],
@@ -186,8 +186,13 @@ def list_assistants(org_id: Optional[int] = None, assistant_type: Optional[Assis
     Args:
         org_id (Optional[int]): The current org id. If None then will try to get from global scope table.
         assistant_type (Optional[AssistantType]): The assistant type.
+
+    Returns:
+        list[ASSISTANT]: The list of assistants. This includes a compound ID that of ID + scope. This is to avoid ID clashes between global and org scope tables on gets.
     """
+    scope = "global"
     if org_id:
+        scope = "org"
         _init(org_id)
 
     sql = ""
@@ -202,31 +207,43 @@ def list_assistants(org_id: Optional[int] = None, assistant_type: Optional[Assis
     ) as connection, closing(connection.cursor()) as cursor:
         cursor.execute(sql, params)
         rows = cursor.fetchall()
-        return [(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]) for row in rows]
+        return [
+            (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], f"{scope}_{row[0]}")
+            for row in rows
+        ]
 
 
-def get_assistant(assistant_id: int, org_id: Optional[int]) -> ASSISTANT:
+def get_assistant(assistant_scoped_id: str, org_id: Optional[int]) -> ASSISTANT:
     """Get the assistant.
 
     If just assistant_id then will try to get from global scope table.
     """
+    scope, id_ = assistant_scoped_id.split("_")
+
     if org_id:
         _init(org_id)
 
-    with closing(
-        sqlite3.connect(__get_assistants_sqlite_file(org_id=org_id), detect_types=sqlite3.PARSE_DECLTYPES)
-    ) as connection, closing(connection.cursor()) as cursor:
+    if scope == "org" and org_id:
+        path = __get_assistants_sqlite_file(org_id=org_id)
+    else:
+        path = __get_assistants_sqlite_file(org_id=None)
+
+    with closing(sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)) as connection, closing(
+        connection.cursor()
+    ) as cursor:
         cursor.execute(
             "SELECT id, name, type, archived, system_prompt_template, user_prompt_template, llm_settings_collection_key, created_at, updated_at FROM assistants WHERE id = ?",
-            (assistant_id,),
+            (id_,),
         )
         row = cursor.fetchone()
         if row is None:
-            if org_id:
-                raise ValueError(f"No Persona with: id = '{assistant_id}' that belongs to org org_id= '{org_id}'")
+            if org_id and scope == "org":
+                raise ValueError(
+                    f"No Persona with: id = '{assistant_scoped_id}' that belongs to org org_id= '{org_id}', scope= '{scope}'"
+                )
             else:
-                raise ValueError(f"No Persona with: id = '{assistant_id}' in global scope.")
-        return (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8])
+                raise ValueError(f"No Persona with: id = '{assistant_scoped_id}' in global scope. scope= '{scope}'")
+        return (row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], assistant_scoped_id)
 
 
 def create_or_update_assistant(

--- a/web/utils/handlers.py
+++ b/web/utils/handlers.py
@@ -610,9 +610,9 @@ def handle_chat_input(feature: domain.FeatureKey) -> None:
     if select_org_id is None:
         raise ValueError("Selected org id was None")
 
-    assistant_id = get_selected_assistant()
+    assistant_scoped_id = get_selected_assistant()
 
-    assistant = get_assistant_or_default(assistant_id, org_id=select_org_id)
+    assistant = get_assistant_or_default(assistant_scoped_id, org_id=select_org_id)
 
     if req.startswith("/agent"):
         data = []

--- a/web/utils/layout.py
+++ b/web/utils/layout.py
@@ -846,15 +846,16 @@ def _render_assistant_selection(feature: FeatureKey) -> None:
         assistants_data_global = list_assistants(assistant_type=assistant_type)
         assistants_data = assistants_data_org + assistants_data_global
 
-        selected_assisted_id = get_selected_assistant()
+        selected_assistant_scoped_id = get_selected_assistant()
 
         selected = render_assistants_selector_ui(
-            assistants_data=assistants_data, selected_assistant_id=selected_assisted_id
+            assistants_data=assistants_data, selected_assistant_scoped_id=selected_assistant_scoped_id
         )
 
         if selected:
-            selected_assisted_id = selected[0]
-            set_selected_assistant(selected_assisted_id)
+            selected_assistant_scoped_id = selected[9]
+            set_selected_assistant(selected_assistant_scoped_id)
+
 
 def _render_chat_file_uploader(feature: FeatureKey, key_suffix: int) -> None:
     """Upload files to chat."""

--- a/web/utils/layout_assistants.py
+++ b/web/utils/layout_assistants.py
@@ -87,14 +87,14 @@ def render_assistant_create_edit_ui(org_id: Optional[int] = None, assistant_data
 
 
 def render_assistants_selector_ui(
-    assistants_data: list[ASSISTANT], selected_assistant_id: Optional[int] = None
+    assistants_data: list[ASSISTANT], selected_assistant_scoped_id: Optional[str] = None
 ) -> ASSISTANT | None:
     """Render assistants selector and create/edit assistant form."""
     selected_index = 0
     selected_assistant = None
-    if selected_assistant_id:
+    if selected_assistant_scoped_id:
         for i, assistant in enumerate(assistants_data):
-            if assistant[0] == selected_assistant_id:
+            if assistant[9] == selected_assistant_scoped_id:
                 selected_assistant = assistant
                 selected_index = i
                 break

--- a/web/utils/sessions.py
+++ b/web/utils/sessions.py
@@ -133,14 +133,23 @@ def set_selected_org_id(org_id: int) -> None:
     """Set the selected org_id context."""
     _set_session_value(org_id, SessionKeySubName.AUTH, SessionKeyNameForAuth.SELECTED_ORG_ID.name)
 
-def set_selected_assistant(assistant_id: int) -> None:
+def set_selected_assistant(assistant_scoped_id: str) -> None:
     """Set the selected person key in session settings."""
-    _set_session_value(assistant_id, SessionKeySubName.SETTINGS, SessionKeyNameForSettings.USER.name, "assistant_id")
+    _set_session_value(
+        assistant_scoped_id, SessionKeySubName.SETTINGS, SessionKeyNameForSettings.USER.name, "assistant_scoped_id"
+    )
 
-def get_selected_assistant() -> int | None:
-    """Get the selected person key from session settings."""
-    assistant_id = _get_session_value(SessionKeySubName.SETTINGS, SessionKeyNameForSettings.USER.name, "assistant_id")
-    return assistant_id
+
+def get_selected_assistant() -> str | None:
+    """Get the selected person key from session settings.
+
+    Returns:
+        str | None: The selected assistant scoped id which is unique across tables.
+    """
+    assistant_scoped_id = _get_session_value(
+        SessionKeySubName.SETTINGS, SessionKeyNameForSettings.USER.name, "assistant_scoped_id"
+    )
+    return assistant_scoped_id
 
 
 def get_username() -> str | None:


### PR DESCRIPTION
## Description
Selecting a global assistant was broken because it was always trying to get from the org scope. However the solution is more complicated given IDs are not unique across the tables.

Added a virtual compound key of scope and id. The scope part gives a hint about where to look.

Fixes/Implements #(issue/feature)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor and code improvement (non-breaking change which improves code quality and/or performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Tests
- [ ] Other chores such as maintenance

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration by modifying the list below.

- [ ] Test A
- [ ] Test B
- [ ] Test C

**Test Configuration**:

Please describe the test setup. List them below as bullet points.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] The commit message follows the convention of this project