### PR TITLE
fix: thread spaces create logic generating none unique names.

### DIFF
--- a/source/docq/run_queries.py
+++ b/source/docq/run_queries.py
@@ -127,7 +127,7 @@ def list_thread_history(feature: FeatureKey, id_: Optional[int] = None) -> list[
     return rows
 
 
-def get_thread_topic(feature: FeatureKey, thread_id: int) -> str:
+def get_thread_topic(feature: FeatureKey, thread_id: int) -> str | None:
     """Retrieve the topic of a thread."""
     tablename = get_history_thread_table_name(feature.type_)
     row = None
@@ -141,7 +141,7 @@ def get_thread_topic(feature: FeatureKey, thread_id: int) -> str:
         )
         row = cursor.execute(f"SELECT topic FROM {tablename} WHERE id = ?", (thread_id,)).fetchone()  # noqa: S608
 
-    return row[0] if row else f"New thread {thread_id}"
+    return row[0] if row else None  # f"New thread {thread_id}"
 
 
 def update_thread_topic(topic: str, feature: FeatureKey, thread_id: int) -> None:

--- a/tests/unit/docq/manage_spaces_test.py
+++ b/tests/unit/docq/manage_spaces_test.py
@@ -225,6 +225,14 @@ def test_create_thread_space(manage_spaces_test_dir: tuple) -> None:
     space_datasource_type = "create_thread_space test ds_type"
     test_thread_id = 1234
 
+    def assert_pattern(thread_id: str, space_summary: str, thread_space_name: str) -> None:
+        import re
+
+        pattern = rf"Thread-{test_thread_id} {space_summary} \d+"
+        assert (
+            re.fullmatch(pattern, thread_space_name) is not None
+        ), f"{thread_space_name} does not match pattern {pattern}"
+
     with patch("docq.manage_spaces.reindex") as reindex:
         from docq.manage_spaces import create_thread_space
         space = create_thread_space(
@@ -239,9 +247,10 @@ def test_create_thread_space(manage_spaces_test_dir: tuple) -> None:
         cursor.execute("SELECT name, summary, datasource_type, datasource_configs FROM spaces WHERE id = ?", (space.id_,))
         result = cursor.fetchone()
         assert result is not None, "Space not found."
-        assert result[0] == f"Thread-{test_thread_id} {space_summary}", "Space name mismatch."
+        # assert result[0] == f"Thread-{test_thread_id} {space_summary}", "Space name mismatch."
         assert result[1] == space_summary, "Space summary mismatch."
         assert result[2] == space_datasource_type, "Space datasource_type mismatch."
+        assert_pattern(str(test_thread_id), space_summary, result[0])
 
     reindex.assert_called_once_with(space)
 

--- a/web/utils/layout.py
+++ b/web/utils/layout.py
@@ -920,7 +920,6 @@ def _render_chat_file_uploader(feature: FeatureKey, key_suffix: int) -> None:
 def chat_ui(feature: FeatureKey) -> None:
     """Chat UI layout."""
     prepare_for_chat(feature)
-    # Style for formatting sources list.
     st.markdown(
         """<style>
             [data-testid="stMarkdownContainer"] h6 {
@@ -1058,8 +1057,11 @@ def chat_ui(feature: FeatureKey) -> None:
     if new_chat.button("New chat"):
         handle_create_new_chat(feature)
         st.rerun()
+
+    thread_id = get_chat_session(feature.type_, SessionKeyNameForChat.THREAD)
+
     with uploader:
-        _render_chat_file_uploader(feature, len(chat_history) if chat_history else 0)
+        _render_chat_file_uploader(feature, thread_id)
 
     _render_show_thread_space_files(feature)
     _render_assistant_selection(feature)


### PR DESCRIPTION
The problem manifested initally when uploading a file in second organisation. The rnd number used for the space name was unique/random enough. generated the same number twice. Have added current milliseconds to the name.

fix: thread space check not checking for global uniqueness.

fix: after inline uploading a doc, clicking new chat not resetting the upload zone due to component key generation not being unique.

## Description

Please include a summary of the change, e.g. what the new feature # is and/or what bug # it fixes. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes/Implements #(issue/feature)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor and code improvement (non-breaking change which improves code quality and/or performance)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Tests
- [ ] Other chores such as maintenance

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration by modifying the list below.

- [ ] Test A
- [ ] Test B
- [ ] Test C

**Test Configuration**:

Please describe the test setup. List them below as bullet points.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] The commit message follows the convention of this project